### PR TITLE
Added 'was_validated' bool to nodes, fixes #3

### DIFF
--- a/dit_cli/evaler.py
+++ b/dit_cli/evaler.py
@@ -30,6 +30,13 @@ def validate_object(obj: Node):
             for list_item in _traverse(attr.data):  # In case it's a list
                 validate_object(list_item)
 
+    # Skip validation if the object has already been validated.
+    # This happens any time an existing object is assigned
+    # as an attribute of another object.
+    if obj.was_validated:
+        return
+    obj.was_validated = True
+
     # Then deal with this object itself
     eva = EvalContext(obj, obj.extends[0], obj.namespace)
     _run_validator(eva)

--- a/dit_cli/node.py
+++ b/dit_cli/node.py
@@ -18,6 +18,7 @@ class Node:
         self.namespace: 'Namespace' = namespace
         self.name: str = name
         self.type_: str = type_
+        self.was_validated: bool = False
 
         self.attrs: List[Attribute] = []
         self.conflicts: List[NameConflict] = []

--- a/tests/dits/eval2.dit
+++ b/tests/dits/eval2.dit
@@ -1,0 +1,69 @@
+// This test confirms the following things:
+// 1. Validators are run once per object
+// 2. Python/NodeJS scripts can read/write to files
+// 3. Deepest attributes are always validated first
+
+// We want to confirm that objects are only validated once.
+// To do this, we create a file with '1' in Initialize,
+// increment it in Increment, and confirm it's value in Finalize.
+
+// This is fairly hackery, but that's probably okay.
+// These are integration tests, not unit tests, after all,
+// and I think weird dits like this should always work.
+// If I break them, that might be okay,
+// but I want to know that.
+
+Initialize {
+    String fileName;
+    validator Python {{
+        with open(@@fileName, 'w') as file_object:
+            file_object.write('1')
+        return True
+    }}
+}
+
+Increment {
+    Initialize init;
+
+    validator Python {{
+        num = 0
+        with open(@@init.fileName) as file_object:
+            num = int(file_object.read())
+        num = num + 1
+        with open(@@init.fileName, 'w') as file_object:
+            file_object.write(str(num))
+        return True
+    }}
+}
+
+Finalize {
+    list Increment inc_list;
+    validator Javascript {{
+        const fs = require('fs');
+        const list = @@inc_list
+        const num = parseInt(fs.readFileSync(list[0].init.fileName, 'utf8'));
+        if (num !== 5) {
+            return `Expected value of 5, was ${num}`;
+        }
+        return true;
+    }}
+}
+
+Increment i(initParam) {
+    init = initParam;
+}
+
+// Will trigger validation first, but not finish, because
+// it's attributes will be run first.
+Finalize finalize;
+
+// Would be validated next, but was already validated (in list below)
+Increment increment;
+
+// Will try to be validated now, but it's already been run.
+Initialize initialize;
+initialize.fileName = '/tmp/dit/dit_eval2_integration_test.txt';
+
+increment.init = initialize;
+
+finalize.inc_list = [increment, i(initialize), i(initialize), i(initialize)];

--- a/tests/test_dit_cli.py
+++ b/tests/test_dit_cli.py
@@ -16,6 +16,7 @@ VALID_STR = 'dit is valid, no errors found'
     ('dits/empty.dit', 'file is empty'),
     ('dits/escape1.dit', VALID_STR),
     ('dits/eval1.dit', VALID_STR),
+    ('dits/eval2.dit', VALID_STR),
     ('dits/inheritance1.dit', VALID_STR),
     ('dits/list1.dit', VALID_STR),
     ('dits/list2.dit', VALID_STR),


### PR DESCRIPTION
Change is fairly self explanatory, I did exactly what I suggested in #3. The only surprise is the integration test, which has scripts that read/write to files in order to count the number of times validators are run. It's a bit hackery, but I would like dits to work that way.

This also comes with changing my workflow in a few ways:
* No more local merges to master, only pull requests.
* Will leave all pull requests open for at least 4 hours. Eventually (and hopefully 🤞) others will review/close them, but for now it will force me to pay attention to what I'm doing and look at the changes I made with fresh eyes after a few hours.
* For now, [GitHub flow](https://guides.github.com/introduction/flow/), only feature branches, no dev/develop branch, no release branches. Everything in master is deployable, but can be pushed long in advance of being deployed. We will probably want [git flow](https://nvie.com/posts/a-successful-git-branching-model/)/hybrid eventually, but it's not necessary right now.

Will publish this info in dev documentation soon.